### PR TITLE
Minor upstream fixes

### DIFF
--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -440,15 +440,15 @@ namespace System.IO.Compression
 
 
             //Get full list of entries
-            List<ZipFileEntry> fullList = _zip.ReadCentralDir();
+            var fullList = _zip.ReadCentralDir();
 
             //In order to delete we need to create a copy of the zip file excluding the selected items
-            string tempZipName = Path.GetTempFileName();
-            string tempEntryName = Path.GetTempFileName();
+            var tempZipName = Path.GetTempFileName();
+            var tempEntryName = Path.GetTempFileName();
 
             try
             {
-                ZipStorer tempZip = ZipStorer.Create(tempZipName, string.Empty);
+                var tempZip = ZipStorer.Create(tempZipName, string.Empty);
 
                 foreach (ZipFileEntry zfe in fullList)
                 {

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -610,7 +610,7 @@ namespace System.IO.Compression
             Stream outStream;
 
             long posStart = this.ZipFileStream.Position;
-            long sourceStart = _source.CanSeek ? 0 : _source.Position;
+            long sourceStart = _source.CanSeek ? _source.Position : 0;
 
             if (_zfe.Method == Compression.Store)
                 outStream = this.ZipFileStream;

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -197,9 +197,8 @@ namespace System.IO.Compression
             if (Access == FileAccess.Read)
                 throw new InvalidOperationException("Writing is not alowed");
 
-            FileStream stream = new FileStream(_pathname, FileMode.Open, FileAccess.Read);
-            AddStream(_method, _filenameInZip, stream, File.GetLastWriteTime(_pathname), _comment);
-            stream.Close();
+			using(var stream = new FileStream(_pathname, FileMode.Open, FileAccess.Read))
+            	AddStream(_method, _filenameInZip, stream, File.GetLastWriteTime(_pathname), _comment);
         }
         /// <summary>
         /// Add full contents of a stream into the Zip storage

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -213,15 +213,6 @@ namespace System.IO.Compression
             if (Access == FileAccess.Read)
                 throw new InvalidOperationException("Writing is not alowed");
 
-            long offset;
-            if (this.Files.Count==0)
-                offset = 0;
-            else
-            {
-                ZipFileEntry last = this.Files[this.Files.Count-1];
-                offset = last.HeaderOffset + last.HeaderSize;
-            }
-
             // Prepare the fileinfo
             ZipFileEntry zfe = new ZipFileEntry();
             zfe.Method = _method;

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -197,8 +197,8 @@ namespace System.IO.Compression
             if (Access == FileAccess.Read)
                 throw new InvalidOperationException("Writing is not alowed");
 
-			using(var stream = new FileStream(_pathname, FileMode.Open, FileAccess.Read))
-            	AddStream(_method, _filenameInZip, stream, File.GetLastWriteTime(_pathname), _comment);
+            using(var stream = new FileStream(_pathname, FileMode.Open, FileAccess.Read))
+                AddStream(_method, _filenameInZip, stream, File.GetLastWriteTime(_pathname), _comment);
         }
         /// <summary>
         /// Add full contents of a stream into the Zip storage

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -340,13 +340,15 @@ namespace System.IO.Compression
             if (Directory.Exists(_filename))
                 return true;
 
-            Stream output = new FileStream(_filename, FileMode.Create, FileAccess.Write);
-            bool result = ExtractFile(_zfe, output);
+            bool result;
+            using(var fs = new FileStream(_filename, FileMode.Create, FileAccess.Write))
+                result = ExtractFile(_zfe, output);
+                
             if (result)
-                output.Close();
-
-            File.SetCreationTime(_filename, _zfe.ModifyTime);
-            File.SetLastWriteTime(_filename, _zfe.ModifyTime);
+            {
+                File.SetCreationTime(_filename, _zfe.ModifyTime);
+                File.SetLastWriteTime(_filename, _zfe.ModifyTime);
+            }
             
             return result;
         }

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -341,7 +341,7 @@ namespace System.IO.Compression
         public bool ExtractFile(ZipFileEntry _zfe, string _filename)
         {
             // Make sure the parent directory exist
-            string path = System.IO.Path.GetDirectoryName(_filename);
+            string path = Path.GetDirectoryName(_filename);
 
             if (!Directory.Exists(path))
                 Directory.CreateDirectory(path);

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -617,7 +617,7 @@ namespace System.IO.Compression
             Stream outStream;
 
             long posStart = this.ZipFileStream.Position;
-            long sourceStart = _source.Position;
+            long sourceStart = _source.CanSeek ? 0 : _source.Position;
 
             if (_zfe.Method == Compression.Store)
                 outStream = this.ZipFileStream;

--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -639,7 +639,7 @@ namespace System.IO.Compression
                         _zfe.Crc32 = ZipStorer.CrcTable[(_zfe.Crc32 ^ buffer[i]) & 0xFF] ^ (_zfe.Crc32 >> 8);
                     }
                 }
-            } while (bytesRead == buffer.Length);
+            } while (bytesRead > 0);
             outStream.Flush();
 
             if (_zfe.Method == Compression.Deflate)


### PR DESCRIPTION
Fixed a few minor issues, each issue has its own commit.
The most important fix is `7be080d` and perhaps `3e7d7e6`, the rest are just style fixes.

I will see if I can create another pull request that fixes the API such that it returns a stream from an `Add` or `Extract` call instead of requiring the stream to be ready for input.