### PR TITLE
Add Two new methods for metadata retrieval

### DIFF
--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -2,6 +2,7 @@
 // Website: http://github.com/jaime-olivares/zipstorer
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -162,7 +163,7 @@ namespace System.IO.Compression
 
             if (zip.readFileInfo())
             {
-                zip.ReadCentralDir();
+                zip.ReadCentralDir(true);
                 return zip;
             }
 
@@ -620,6 +621,31 @@ namespace System.IO.Compression
                     File.Delete(tempZipName);
             }
             return true;
+        }
+
+        /// <summary>
+        /// Returns a list of all file entries.
+        /// </summary>
+        /// <returns>List of all entries (central directory and newly added)</returns>
+        public List<ZipFileEntry> GetEntries()
+        {
+            var list = new List<ZipFileEntry>(CentralDirectoryFiles);
+            list.AddRange(Files);
+            return list;
+        }
+
+        /// <summary>
+        /// Returns the entry with the specified name.
+        /// </summary>
+        /// <param name="name">Name to search for</param>
+        /// <param name="comparisonType">StringComparison enum value</param>
+        /// <returns>ZipFileEntry found or null</returns>
+        /// <remarks>Searching with IgnoreCase in a Linux zip archive returns only the first entry found.</remarks>
+        public ZipFileEntry GetEntry(string name, StringComparison comparisonType = StringComparison.CurrentCultureIgnoreCase)
+        {
+            var entry = CentralDirectoryFiles.Where(x => x.FilenameInZip.Equals(name, comparisonType)).FirstOrDefault();
+            if (entry is null) entry = Files.Where(x => x.FilenameInZip.Equals(name, comparisonType)).FirstOrDefault();
+            return entry;
         }
         #endregion
 


### PR DESCRIPTION
Metadata can be retrieved with `ReadCentralDir`.
The data for newly added files is appended to the stream, but the central directory information is not updated until the archive is closed. Until then, the `ZipFileEntry` for a newly added file is just added to an internal list.
As `ReadCentralDir` should remain untouched, it would be nice to have two methods `GetEntries` and `GetEntry` to retrieve the entire list or search for a specific entry.

The new version has two methods that evaluate both metadata sources to prepare the result.

Fixes #58
