### PR TITLE
Fix issue #67 Error in ReadCentralDir

### DIFF
--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -98,7 +98,8 @@ namespace System.IO.Compression
                 Comment = comment ?? string.Empty,
                 ZipFileStream = stream,
                 Access = FileAccess.Write,
-                LeaveOpen = leaveOpen
+                LeaveOpen = leaveOpen,
+                CentralDirImage = new byte[0]
             };
 
             return zip;


### PR DESCRIPTION
Initialize `CentralDirImage` in `Create` with an empty array.