### PR TITLE
Fix issue # 68 Open method cannot open empty ZIP files

### DIFF
--- a/src/ZipStorer.cs
+++ b/src/ZipStorer.cs
@@ -964,9 +964,9 @@ namespace System.IO.Compression
             var br = new BinaryReader(this.ZipFileStream);
             UInt32 headerSig = br.ReadUInt32();
 
-            if (headerSig != 0x04034b50)
+            if (headerSig != 0x04034b50 && headerSig != 0x06054b50)
             {
-                // not PK.. signature header
+                // not PK.. signature header and not 'end of central directory record' (empty ZIP files)
                 return false;
             }
 


### PR DESCRIPTION
This PR fixes the issue with empty ZIP files in `Open`.